### PR TITLE
adding convert.com code to the EN new_tab_learn_more

### DIFF
--- a/content/en/firefox/new_tab_learn_more/index.html
+++ b/content/en/firefox/new_tab_learn_more/index.html
@@ -4,6 +4,9 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Pocket</title>
+    <!-- begin Convert Experiences code--> 
+    <script type="text/javascript" src="https://cdn-3.convertexperiments.com/js/10039-10033300.js"></script> 
+    <!-- end Convert Experiences code -->
     <!-- OneTrust Cookies Consent Notice start for getpocket.com -->
     <script
       type="text/javascript"


### PR DESCRIPTION
This will add the convert.com code to the en new_tab_learn_more page on the static pocket marketing site.

I would like to test this on staging, but before we ever merge to production we should answer:

- Is convert.com the right way to handle A/B testing for static pocket pages?
- Is adding convert.com code directly to the page the correct approach? (we did this for vpn.mozilla.org)