### PR TITLE
(fix): broken press kit links

### DIFF
--- a/content/de/about/index.html
+++ b/content/de/about/index.html
@@ -452,7 +452,7 @@
                 >Unsere Bilder und unsere Pressemappe stehen
                 <a
                   id="press-page"
-                  href="https://getpocket.com/de-DE/blog.getpocket.com/press/"
+                  href="https://blog.getpocket.com/press/"
                   >hier</a
                 >
                 zum Download zur Verfügung.</span

--- a/content/en/about/index.html
+++ b/content/en/about/index.html
@@ -443,7 +443,7 @@
                 >Download our images and press kit
                 <a
                   id="press-page"
-                  href="https://getpocket.com/en/blog.getpocket.com/press/"
+                  href="https://blog.getpocket.com/press/"
                   >here</a
                 >.</span
               >

--- a/content/es-LA/about/index.html
+++ b/content/es-LA/about/index.html
@@ -450,7 +450,7 @@
                 >Descarga nuestras imágenes y el paquete de prensa
                 <a
                   id="press-page"
-                  href="https://getpocket.com/es-LA/blog.getpocket.com/press/"
+                  href="https://blog.getpocket.com/press/"
                   >aquí</a
                 >.</span
               >

--- a/content/es/about/index.html
+++ b/content/es/about/index.html
@@ -450,7 +450,7 @@
                 >Descarga nuestras imágenes y nuestro kit de prensa
                 <a
                   id="press-page"
-                  href="https://getpocket.com/es-ES/blog.getpocket.com/press/"
+                  href="https://blog.getpocket.com/press/"
                   >aquí</a
                 >.</span
               >

--- a/content/fr-CA/about/index.html
+++ b/content/fr-CA/about/index.html
@@ -458,7 +458,7 @@
                 >Téléchargez nos images et notre dossier de presse
                 <a
                   id="press-page"
-                  href="https://getpocket.com/fr-CA/blog.getpocket.com/press/"
+                  href="https://blog.getpocket.com/press/"
                   >ici</a
                 >.</span
               >

--- a/content/fr/about/index.html
+++ b/content/fr/about/index.html
@@ -461,7 +461,7 @@
                 >Téléchargez nos images et notre dossier de presse
                 <a
                   id="press-page"
-                  href="https://getpocket.com/fr-FR/blog.getpocket.com/press/"
+                  href="https://blog.getpocket.com/press/"
                   >ici</a
                 >.</span
               >

--- a/content/it/about/index.html
+++ b/content/it/about/index.html
@@ -446,7 +446,7 @@
                 >Scarica
                 <a
                   id="press-page"
-                  href="https://getpocket.com/it-IT/blog.getpocket.com/press/"
+                  href="https://blog.getpocket.com/press/"
                   >qui</a
                 >le nostre immagini e la cartella stampa.</span
               >

--- a/content/ja/about/index.html
+++ b/content/ja/about/index.html
@@ -434,7 +434,7 @@
               までご連絡ください。<span
                 >Pocket の画像とプレスキットは<a
                   id="press-page"
-                  href="https://getpocket.com/ja-JP/blog.getpocket.com/press/"
+                  href="https://blog.getpocket.com/press/"
                   >こちら</a
                 >からダウンロードできます。</span
               >

--- a/content/ko/about/index.html
+++ b/content/ko/about/index.html
@@ -438,7 +438,7 @@
                 >이미지와 보도 자료 키트는
                 <a
                   id="press-page"
-                  href="https://getpocket.com/ko-KR/blog.getpocket.com/press/"
+                  href="https://blog.getpocket.com/press/"
                   >여기</a
                 >서 다운로드할 수 있습니다.</span
               >

--- a/content/nl/about/index.html
+++ b/content/nl/about/index.html
@@ -455,7 +455,7 @@
                 >Download onze afbeeldingen en persmap
                 <a
                   id="press-page"
-                  href="https://getpocket.com/nl-NL/blog.getpocket.com/press/"
+                  href="https://blog.getpocket.com/press/"
                   >hier</a
                 >.</span
               >

--- a/content/pl/about/index.html
+++ b/content/pl/about/index.html
@@ -444,7 +444,7 @@
               <span
                 ><a
                   id="press-page"
-                  href="https://getpocket.com/pl-PL/blog.getpocket.com/press/"
+                  href="https://blog.getpocket.com/press/"
                   >Tutaj</a
                 >
                 znajdziesz nasze obrazy i materiały prasowe.</span

--- a/content/pt-BR/about/index.html
+++ b/content/pt-BR/about/index.html
@@ -448,7 +448,7 @@
                 >Baixe as nossas imagens e o kit de imprensa
                 <a
                   id="press-page"
-                  href="https://getpocket.com/pt-BR/blog.getpocket.com/press/"
+                  href="https://blog.getpocket.com/press/"
                   >aqui</a
                 >.</span
               >

--- a/content/pt/about/index.html
+++ b/content/pt/about/index.html
@@ -449,7 +449,7 @@
                 >Faça transferência das nossas imagens e kit de imprensa
                 <a
                   id="press-page"
-                  href="https://getpocket.com/pt-PT/blog.getpocket.com/press/"
+                  href="https://blog.getpocket.com/press/"
                   >aqui</a
                 >.</span
               >

--- a/content/ru/about/index.html
+++ b/content/ru/about/index.html
@@ -444,7 +444,7 @@
                 >Загрузите изображения и пресс-кит
                 <a
                   id="press-page"
-                  href="https://getpocket.com/ru-RU/blog.getpocket.com/press/"
+                  href="https://blog.getpocket.com/press/"
                   >здесь</a
                 >.</span
               >

--- a/content/zh-CN/about/index.html
+++ b/content/zh-CN/about/index.html
@@ -428,7 +428,7 @@
               >。<span
                 >在<a
                   id="press-page"
-                  href="https://getpocket.com/zh-CN/blog.getpocket.com/press/"
+                  href="https://blog.getpocket.com/press/"
                   >此处</a
                 >下载我们的图像和新闻包。</span
               >

--- a/content/zh-TW/about/index.html
+++ b/content/zh-TW/about/index.html
@@ -427,7 +427,7 @@
               >。<span
                 >在<a
                   id="press-page"
-                  href="https://getpocket.com/zh-TW/blog.getpocket.com/press/"
+                  href="https://blog.getpocket.com/press/"
                   >此處</a
                 >下載我們的影像和媒體資料。</span
               >


### PR DESCRIPTION
The link to the press kit on the /about page is broken due to appending getpocket.com.