### PR TITLE
fix(jobs): fixing link to Mozilla Careers page

### DIFF
--- a/content/en/jobs/index.html
+++ b/content/en/jobs/index.html
@@ -257,7 +257,7 @@
               <div class="jobs-listings">
                 <section>
                   <h5>Current Positions</h5>
-                  <p><a href="https://careers.mozilla.org/listings/?team=Pocket" target="_blank" rel="noopener noreferrer">See our latest job openings</a></p>
+                  <p><a href="https://careers.mozilla.org/listings/?team=Core%20Product-Pocket" target="_blank" rel="noopener noreferrer">See our latest job openings</a></p>
                 </section>
               </div>
               <div class="figs-wrapper">


### PR DESCRIPTION
The link to the Mozilla Careers page changed so the results weren't being filtered to Pocket